### PR TITLE
Add NodesContainEntityIds rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ The `pageInfo` field [is specified by the Relay cursor connections specification
 
 As many schemas will have a nonzero number of exceptions to this rule, fields can be marked with an `@allowNonNull` decorator (which you must add to your schema) to skip this rule as well. Standard [`graphql-schema-linter` overrides](https://github.com/cjoudrey/graphql-schema-linter#inline-rule-overrides) will work as well.
 
+### `nodes-contain-entity-id`
+
+When a type implements the `Node` interface, it must contain a non-nullable string named `entityId`.
+
+#### Rationale
+
+For cross-compatibility with other APIs, our model types need to expose the primary identifier that can be used to identify the object across services. We do not, however, want to use `Node`'s `id` field for this identifier, as clients expect `id` to be globally unique across model and type (which our primary identifier is not). By enforcing the presence of `entityId`, we ensure there is a field to expose both, without changing the standard `Node` interface and still allowing for exceptional cases.
+
 ## Contributing
 
 See [`CONTRIBUTING.md`](CONTRIBUTING.md).

--- a/src/rules/nodesContainEntityId.ts
+++ b/src/rules/nodesContainEntityId.ts
@@ -1,0 +1,40 @@
+import {
+  ASTVisitor,
+  FieldDefinitionNode,
+  NamedTypeNode,
+  ValidationContext,
+} from 'graphql';
+
+import { isNamedTypeNode, isNonNullTypeNode, ValidationError } from '../utils';
+
+function isProperEntityIdField(field: FieldDefinitionNode): boolean {
+  return (
+    field.name.value == 'entityId' &&
+    isNonNullTypeNode(field.type) &&
+    isNamedTypeNode(field.type.type) &&
+    field.type.type.name.value == 'String'
+  );
+}
+
+export function NodesContainEntityId(context: ValidationContext): ASTVisitor {
+  return {
+    ObjectTypeDefinition(node) {
+      if (
+        node.interfaces?.some(
+          (iface: NamedTypeNode) => iface.name.value == 'Node',
+        ) &&
+        !node.fields?.some((field: FieldDefinitionNode) =>
+          isProperEntityIdField(field),
+        )
+      ) {
+        context.reportError(
+          new ValidationError(
+            'nodes-contain-entity-id',
+            `The Node type \`${node.name.value}\` must have a non-nullable "entityId" string.`,
+            [node],
+          ),
+        );
+      }
+    },
+  };
+}

--- a/test/rules/testNodesContainEntityId.ts
+++ b/test/rules/testNodesContainEntityId.ts
@@ -1,0 +1,102 @@
+import { NodesContainEntityId } from '../../src/rules/nodesContainEntityId';
+
+import { gql } from '../utils';
+
+import { expectPassesRule, expectFailsRule } from '../assertions';
+
+describe('NodesContainEntityId rule', () => {
+  it('allows Node types that have a non-nullable entityId string', () => {
+    expectPassesRule(
+      NodesContainEntityId,
+      gql`
+        scalar ID
+        interface Node {
+          id: ID!
+        }
+        type Entity implements Node {
+          id: ID!
+          entityId: String!
+        }
+      `,
+    );
+  });
+
+  it('disallows Node types where entityId is nullable', () => {
+    expectFailsRule(
+      NodesContainEntityId,
+      gql`
+        scalar ID
+        interface Node {
+          id: ID!
+        }
+        type Entity implements Node {
+          id: ID!
+          entityId: String
+        }
+      `,
+      [
+        {
+          message:
+            'The Node type `Entity` must have a non-nullable "entityId" string.',
+          locations: [{ line: 6, column: 9 }],
+        },
+      ],
+    );
+  });
+
+  it('disallows Node types where entityId is not a string', () => {
+    expectFailsRule(
+      NodesContainEntityId,
+      gql`
+        scalar ID
+        interface Node {
+          id: ID!
+        }
+        type Entity implements Node {
+          id: ID!
+          entityId: Int!
+        }
+      `,
+      [
+        {
+          message:
+            'The Node type `Entity` must have a non-nullable "entityId" string.',
+          locations: [{ line: 6, column: 9 }],
+        },
+      ],
+    );
+  });
+
+  it('disallows Node types where entityId is missing', () => {
+    expectFailsRule(
+      NodesContainEntityId,
+      gql`
+        scalar ID
+        interface Node {
+          id: ID!
+        }
+        type Entity implements Node {
+          id: ID!
+        }
+      `,
+      [
+        {
+          message:
+            'The Node type `Entity` must have a non-nullable "entityId" string.',
+          locations: [{ line: 6, column: 9 }],
+        },
+      ],
+    );
+  });
+
+  it('skips entities that do not implement Node', () => {
+    expectPassesRule(
+      NodesContainEntityId,
+      gql`
+        type Entity {
+          entityId: Int
+        }
+      `,
+    );
+  });
+});


### PR DESCRIPTION
For cross-compatibility with other APIs, our model types need to expose the primary identifier that can be used to identify the object across services. We do not, however, want to use `Node`'s `id` field for this identifier, as clients expect `id` to be globally unique across model and type (which our primary identifier is not). By enforcing the presence of `entityId`, we ensure there is a field to expose both, without changing the standard `Node` interface and still allowing for exceptional cases.