### PR TITLE
fix(workflows): Create commit with updated package.json

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./pinterest-graphql-lint-rules-${{ steps.semantic.output.new_release_version }}.tgz
-        asset_name: pinterest-graphql-lint-rules-${{ steps.semantic.output.new_release_version }}.tgz
+        asset_path: ./pinterest-graphql-lint-rules-${{ steps.semantic.outputs.new_release_version }}.tgz
+        asset_name: pinterest-graphql-lint-rules-${{ steps.semantic.outputs.new_release_version }}.tgz
         asset_content_type: application/gzip

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -19,6 +19,19 @@
       {
         "preset": "conventionalcommits"
       }
+    ],
+    [
+      "@semantic-release/npm",
+      {
+        "npmPublish": false
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}",
+        "assets": ["rules/**/*.js", "package.json"]
+      }
     ]
   ]
 }


### PR DESCRIPTION
This adds the [`npm`](https://github.com/semantic-release/npm) and [`git`](https://github.com/semantic-release/git) plugins to semantic-release so that on release, it will update the version specified in `package.json` and generate a new commit with the update.

The result should be a release commit that serves as the HEAD of the release tag we create later in the workflow.

This also fixes a bug in the workflow that prevented us from getting the right tarball.