### PR TITLE
fix(workflows): Add git as extra_plugin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ jobs:
       uses: cycjimmy/semantic-release-action@v2
       with:
         semantic_version: 18.0.1
+        extra_plugins: |
+          @semantic-release/git
     - name: Create Release
       if: steps.semantic.outputs.new_release_published == 'true'
       id: create_release


### PR DESCRIPTION
`@semantic-release/git` is not in the set of [default plugins](https://semantic-release.gitbook.io/semantic-release/usage/plugins#default-plugins), so it must be installed explicitly by adding it to the [`extra_plugins`](https://github.com/cycjimmy/semantic-release-action#extra_plugins) configuration for the `semantic-release-action`.