### PR TITLE
feat(dev): Use gitattributes to mark rules as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+rules/** linguist-generated


### PR DESCRIPTION
This hints to Linguist (used by GitHub diff views) that files in the `rules/` directory should be displayed as generated code and collapsed by default.
These files are the generated JavaScript code from the TypeScript source, and do not need to be reviewed.