### PR TITLE
fix: Remove assert package to avoid circular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,16 +9,15 @@
       "version": "2.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@rollup/plugin-commonjs": "^17.0.0",
+        "@rollup/plugin-commonjs": "^22.0.0",
         "@rollup/plugin-json": "^4.1.0",
-        "@rollup/plugin-node-resolve": "^11.0.0",
+        "@rollup/plugin-node-resolve": "^13.3.0",
         "@rollup/plugin-typescript": "^8.3.2",
         "@tsconfig/node16-strictest-esm": "^1.0.1",
         "@types/mocha": "^9.1.1",
         "@types/node": "^16",
         "@typescript-eslint/eslint-plugin": "^5.26.0",
         "@typescript-eslint/parser": "^5.26.0",
-        "assert": "^2.0.0",
         "conventional-changelog-conventionalcommits": "^4.5.0",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^7.1.0",
@@ -409,10 +408,9 @@
       }
     },
     "node_modules/@rollup/plugin-commonjs": {
-      "version": "17.1.0",
-      "integrity": "sha1-dX7Ihzff+oqpE+s5L63i5FrvKi0=",
+      "version": "22.0.0",
+      "integrity": "sha512-Ktvf2j+bAO+30awhbYoCaXpBcyPmJbaEUYClQns/+6SNCYFURbvBiNbWgHITEsIgDDWCDUclWRKEuf8cwZCFoQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@rollup/pluginutils": "^3.1.0",
         "commondir": "^1.0.1",
@@ -423,10 +421,10 @@
         "resolve": "^1.17.0"
       },
       "engines": {
-        "node": ">= 8.0.0"
+        "node": ">= 12.0.0"
       },
       "peerDependencies": {
-        "rollup": "^2.30.0"
+        "rollup": "^2.68.0"
       }
     },
     "node_modules/@rollup/plugin-json": {
@@ -442,15 +440,14 @@
       }
     },
     "node_modules/@rollup/plugin-node-resolve": {
-      "version": "11.2.1",
-      "integrity": "sha1-gqpZOXopzU4TJIsQbmpKGIA2KmA=",
+      "version": "13.3.0",
+      "integrity": "sha512-Lus8rbUo1eEcnS4yTFKLZrVumLPY+YayBdWXgFSHYhTT2iJbMhoaaBL3xl5NCdeRytErGr8tZ0L71BMRmnlwSw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@rollup/pluginutils": "^3.1.0",
         "@types/resolve": "1.17.1",
-        "builtin-modules": "^3.1.0",
         "deepmerge": "^4.2.2",
+        "is-builtin-module": "^3.1.0",
         "is-module": "^1.0.0",
         "resolve": "^1.19.0"
       },
@@ -458,7 +455,7 @@
         "node": ">= 10.0.0"
       },
       "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0"
+        "rollup": "^2.42.0"
       }
     },
     "node_modules/@rollup/plugin-typescript": {
@@ -1100,18 +1097,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/assert": {
-      "version": "2.0.0",
-      "integrity": "sha1-lfwcYW1IcTUQaA8ury0Q3SLgLTI=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es6-object-assign": "^1.1.0",
-        "is-nan": "^1.2.1",
-        "object-is": "^1.0.1",
-        "util": "^0.12.0"
-      }
-    },
     "node_modules/astral-regex": {
       "version": "2.0.0",
       "integrity": "sha1-SDFDxWeu7UeFdZwIZXhtx319LjE=",
@@ -1119,18 +1104,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/available-typed-arrays": {
-      "version": "1.0.5",
-      "integrity": "sha1-kvlWFlAQadB9EO2y/DfT4cZRI7c=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/balanced-match": {
@@ -1190,27 +1163,13 @@
     },
     "node_modules/builtin-modules": {
       "version": "3.3.0",
-      "integrity": "sha1-yuYoEriYAellYzbkYiPgMDhr57Y=",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/call-bind": {
-      "version": "1.0.2",
-      "integrity": "sha1-sdTonmiBGcPJqQOtMKuy9qkZvjw=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/caller-callsite": {
@@ -1420,9 +1379,8 @@
     },
     "node_modules/commondir": {
       "version": "1.0.1",
-      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
-      "dev": true,
-      "license": "MIT"
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true
     },
     "node_modules/compare-func": {
       "version": "2.0.0",
@@ -1705,22 +1663,6 @@
         "clone": "^1.0.2"
       }
     },
-    "node_modules/define-properties": {
-      "version": "1.1.4",
-      "integrity": "sha1-CxTXvX++svNXLDp+2oDqXVf7BbE=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-property-descriptors": "^1.0.0",
-        "object-keys": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/del": {
       "version": "6.1.1",
       "integrity": "sha1-O3AxTx7AqjJcaxTrNrlXhmce23o=",
@@ -1858,66 +1800,6 @@
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
-    },
-    "node_modules/es-abstract": {
-      "version": "1.20.1",
-      "integrity": "sha1-AnKSzW70S9ErGRO4KBFvVHh9GBQ=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "es-to-primitive": "^1.2.1",
-        "function-bind": "^1.1.1",
-        "function.prototype.name": "^1.1.5",
-        "get-intrinsic": "^1.1.1",
-        "get-symbol-description": "^1.0.0",
-        "has": "^1.0.3",
-        "has-property-descriptors": "^1.0.0",
-        "has-symbols": "^1.0.3",
-        "internal-slot": "^1.0.3",
-        "is-callable": "^1.2.4",
-        "is-negative-zero": "^2.0.2",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
-        "is-string": "^1.0.7",
-        "is-weakref": "^1.0.2",
-        "object-inspect": "^1.12.0",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.2",
-        "regexp.prototype.flags": "^1.4.3",
-        "string.prototype.trimend": "^1.0.5",
-        "string.prototype.trimstart": "^1.0.5",
-        "unbox-primitive": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/es-to-primitive": {
-      "version": "1.2.1",
-      "integrity": "sha1-5VzUyc3BiLzvsDs2bHNjI/xciYo=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-callable": "^1.1.4",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/es6-object-assign": {
-      "version": "1.1.0",
-      "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -2210,9 +2092,8 @@
     },
     "node_modules/estree-walker": {
       "version": "2.0.2",
-      "integrity": "sha1-UvAQF4wqTBF6d1fP6UKtt9LaTKw=",
-      "dev": true,
-      "license": "MIT"
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true
     },
     "node_modules/esutils": {
       "version": "2.0.3",
@@ -2402,15 +2283,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/for-each": {
-      "version": "0.3.3",
-      "integrity": "sha1-abRH6IoKXTLD5whPPxcQA0shN24=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-callable": "^1.1.3"
-      }
-    },
     "node_modules/from2": {
       "version": "2.3.0",
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
@@ -2481,38 +2353,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/function.prototype.name": {
-      "version": "1.1.5",
-      "integrity": "sha1-zOBQX+H/uAUD5vnkbMZORqEqliE=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.0",
-        "functions-have-names": "^1.2.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/functional-red-black-tree": {
       "version": "1.0.1",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/functions-have-names": {
-      "version": "1.2.3",
-      "integrity": "sha1-BAT+TuK6L2B/Dg7DyAuumUEzuDQ=",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -2521,20 +2366,6 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/get-intrinsic": {
-      "version": "1.1.1",
-      "integrity": "sha1-FfWfN2+FXERpY5SPDSTNNje0q8Y=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-stream": {
@@ -2547,22 +2378,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/get-symbol-description": {
-      "version": "1.0.0",
-      "integrity": "sha1-f9uByQAQH71WTdXxowr1qtweWNY=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/git-log-parser": {
@@ -2821,15 +2636,6 @@
         "node": ">= 0.4.0"
       }
     },
-    "node_modules/has-bigints": {
-      "version": "1.0.2",
-      "integrity": "sha1-CHG9Pj1RYm9soJZmaLo11WAtbqo=",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
@@ -2837,45 +2643,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/has-property-descriptors": {
-      "version": "1.0.0",
-      "integrity": "sha1-YQcIYAYG02lh7QTBlhk7amB/qGE=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-intrinsic": "^1.1.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.0.3",
-      "integrity": "sha1-u3ssQ0klHc6HsSX3vfh0qnyLOfg=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.0",
-      "integrity": "sha1-fhM4GKfTlHNPlB5zw9P5KR5liyU=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/he": {
@@ -3021,20 +2788,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/internal-slot": {
-      "version": "1.0.3",
-      "integrity": "sha1-c0fjB97uovqsKsYgXUvH00ln9Zw=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-intrinsic": "^1.1.0",
-        "has": "^1.0.3",
-        "side-channel": "^1.0.4"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/into-stream": {
       "version": "6.0.0",
       "integrity": "sha1-S/wSRMASgiThi4hw6Fst6OZsZwI=",
@@ -3051,39 +2804,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-arguments": {
-      "version": "1.1.1",
-      "integrity": "sha1-FbP4j9oB8ql/7ITKdhpWDxI++ps=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/is-bigint": {
-      "version": "1.0.4",
-      "integrity": "sha1-CBR6GHW8KzIAXUHM2Ckd/8ZpHfM=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-bigints": "^1.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -3097,32 +2822,15 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-boolean-object": {
-      "version": "1.1.2",
-      "integrity": "sha1-XG3CACRt2TIa5LiFoRS7H3X2Nxk=",
+    "node_modules/is-builtin-module": {
+      "version": "3.1.0",
+      "integrity": "sha512-OV7JjAgOTfAFJmHZLvpSTb4qi0nIILDV1gWPYDnDJUTNFM5aGlRAhk4QcT8i7TuAleeEV5Fdkqn3t4mS+Q11fg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
+        "builtin-modules": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-callable": {
-      "version": "1.2.4",
-      "integrity": "sha1-RzAdWN0CWUB4ZVR4U99tYf5HGUU=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "node": ">=6"
       }
     },
     "node_modules/is-core-module": {
@@ -3132,21 +2840,6 @@
       "license": "MIT",
       "dependencies": {
         "has": "^1.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-date-object": {
-      "version": "1.0.5",
-      "integrity": "sha1-CEHVU25yTCVZe/bqYuG9OCmN8x8=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3179,21 +2872,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-generator-function": {
-      "version": "1.0.10",
-      "integrity": "sha1-8VWLrxrBfg3up8BBXEODUf8rPHI=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "integrity": "sha1-ZPYeQsu7LuwgcanawLKLoeZdUIQ=",
@@ -3212,34 +2890,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/is-nan": {
-      "version": "1.3.2",
-      "integrity": "sha1-BDpUreoxdItVts1OCara+mm9nh0=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-negative-zero": {
-      "version": "2.0.2",
-      "integrity": "sha1-e/bwOigAO4s5Zd46wm9mTXZfMVA=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=",
@@ -3247,21 +2897,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
-      }
-    },
-    "node_modules/is-number-object": {
-      "version": "1.0.7",
-      "integrity": "sha1-WdUK2kxFJReE6ZBPUkbHQvB6Qvw=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-obj": {
@@ -3311,39 +2946,10 @@
     },
     "node_modules/is-reference": {
       "version": "1.2.1",
-      "integrity": "sha1-iy2sCzcfS8mU/eq6nrVC0DAC0Lc=",
+      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/estree": "*"
-      }
-    },
-    "node_modules/is-regex": {
-      "version": "1.1.4",
-      "integrity": "sha1-7vVmPNWfpMCuM5UFMj32hUuxWVg=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-shared-array-buffer": {
-      "version": "1.0.2",
-      "integrity": "sha1-jyWcVztgtqMtQFihoHQwwKc0THk=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-stream": {
@@ -3358,36 +2964,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-string": {
-      "version": "1.0.7",
-      "integrity": "sha1-DdEr8gBvJVu1j2lREO/3SR7rwP0=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-symbol": {
-      "version": "1.0.4",
-      "integrity": "sha1-ptrJO2NbBjymhyI23oiRClevE5w=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-text-path": {
       "version": "1.0.1",
       "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
@@ -3400,25 +2976,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-typed-array": {
-      "version": "1.1.9",
-      "integrity": "sha1-JG130ocefZ9a6x1UufUscTKezmc=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
-        "es-abstract": "^1.20.0",
-        "for-each": "^0.3.3",
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
       "integrity": "sha1-PybHaoCVk7Ur+i7LVxDtJ3m1Iqc=",
@@ -3429,18 +2986,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-weakref": {
-      "version": "1.0.2",
-      "integrity": "sha1-lSnzg6kzggXol2XgOS78LxAPBvI=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/isarray": {
@@ -3708,9 +3253,8 @@
     },
     "node_modules/magic-string": {
       "version": "0.25.9",
-      "integrity": "sha1-3n+fr5HvihyR0CwuUxTIJ3283Rw=",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "sourcemap-codec": "^1.4.8"
       }
@@ -6578,58 +6122,6 @@
       "inBundle": true,
       "license": "ISC"
     },
-    "node_modules/object-inspect": {
-      "version": "1.12.0",
-      "integrity": "sha1-biwSDoaP0f0Yy08YwxdB0NbndvA=",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object-is": {
-      "version": "1.1.5",
-      "integrity": "sha1-ud7qpfx/GEag+uzc7sE45XePU6w=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object-keys": {
-      "version": "1.1.1",
-      "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/object.assign": {
-      "version": "4.1.2",
-      "integrity": "sha1-DtVKNC7Os3s4/3brgxoOeIy2OUA=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3",
-        "has-symbols": "^1.0.1",
-        "object-keys": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/once": {
       "version": "1.4.0",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
@@ -7270,23 +6762,6 @@
         "esprima": "~4.0.0"
       }
     },
-    "node_modules/regexp.prototype.flags": {
-      "version": "1.4.3",
-      "integrity": "sha1-h8qzD4D2ZmAYGju3v1mBqHKzZ6w=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "functions-have-names": "^1.2.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/regexpp": {
       "version": "3.2.0",
       "integrity": "sha1-BCWido2PI7rXDKS5BGH6LxIT4bI=",
@@ -7607,20 +7082,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/side-channel": {
-      "version": "1.0.4",
-      "integrity": "sha1-785cj9wQTudRslxY1CkAEfpeos8=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "integrity": "sha1-qaF2f4r4QVURTqq9c/mSc8j1mtk=",
@@ -7761,9 +7222,8 @@
     },
     "node_modules/sourcemap-codec": {
       "version": "1.4.8",
-      "integrity": "sha1-6oBL2UhXQC5pktBaOO8a41qatMQ=",
-      "dev": true,
-      "license": "MIT"
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true
     },
     "node_modules/spawn-error-forwarder": {
       "version": "1.0.0",
@@ -7875,34 +7335,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/string.prototype.trimend": {
-      "version": "1.0.5",
-      "integrity": "sha1-kUpluqqyX73U7ikcp93lfoacuNA=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/string.prototype.trimstart": {
-      "version": "1.0.5",
-      "integrity": "sha1-VGbZO6WM+iE0g5+B1/QkN+jAH+8=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/strip-ansi": {
@@ -8292,21 +7724,6 @@
         "node": ">=0.8.0"
       }
     },
-    "node_modules/unbox-primitive": {
-      "version": "1.0.2",
-      "integrity": "sha1-KQMgIQV9Xmzb0IxRKcIm3/jtb54=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-bigints": "^1.0.2",
-        "has-symbols": "^1.0.3",
-        "which-boxed-primitive": "^1.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/unique-string": {
       "version": "2.0.0",
       "integrity": "sha1-OcZFH4GvsnSd4rIz4/fF6IQ72J0=",
@@ -8348,20 +7765,6 @@
       "integrity": "sha1-tkLiGiZGgI/6F4xMX9o5hE4Szec=",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/util": {
-      "version": "0.12.4",
-      "integrity": "sha1-ZhIaMUIN+PAcoMRkvhXfodGFAlM=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "is-arguments": "^1.0.4",
-        "is-generator-function": "^1.0.7",
-        "is-typed-array": "^1.1.3",
-        "safe-buffer": "^5.1.2",
-        "which-typed-array": "^1.1.2"
-      }
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -8429,42 +7832,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/which-boxed-primitive": {
-      "version": "1.0.2",
-      "integrity": "sha1-E3V7yJsgmwSf5dhkMOIc9AqJqOY=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-bigint": "^1.0.1",
-        "is-boolean-object": "^1.1.0",
-        "is-number-object": "^1.0.4",
-        "is-string": "^1.0.5",
-        "is-symbol": "^1.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/which-typed-array": {
-      "version": "1.1.8",
-      "integrity": "sha1-DP1TQBpvM02Q7REldUpC7WY+sB8=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
-        "es-abstract": "^1.20.0",
-        "for-each": "^0.3.3",
-        "has-tostringtag": "^1.0.0",
-        "is-typed-array": "^1.1.9"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/word-wrap": {
@@ -8923,8 +8290,8 @@
       }
     },
     "@rollup/plugin-commonjs": {
-      "version": "17.1.0",
-      "integrity": "sha1-dX7Ihzff+oqpE+s5L63i5FrvKi0=",
+      "version": "22.0.0",
+      "integrity": "sha512-Ktvf2j+bAO+30awhbYoCaXpBcyPmJbaEUYClQns/+6SNCYFURbvBiNbWgHITEsIgDDWCDUclWRKEuf8cwZCFoQ==",
       "dev": true,
       "requires": {
         "@rollup/pluginutils": "^3.1.0",
@@ -8945,14 +8312,14 @@
       }
     },
     "@rollup/plugin-node-resolve": {
-      "version": "11.2.1",
-      "integrity": "sha1-gqpZOXopzU4TJIsQbmpKGIA2KmA=",
+      "version": "13.3.0",
+      "integrity": "sha512-Lus8rbUo1eEcnS4yTFKLZrVumLPY+YayBdWXgFSHYhTT2iJbMhoaaBL3xl5NCdeRytErGr8tZ0L71BMRmnlwSw==",
       "dev": true,
       "requires": {
         "@rollup/pluginutils": "^3.1.0",
         "@types/resolve": "1.17.1",
-        "builtin-modules": "^3.1.0",
         "deepmerge": "^4.2.2",
+        "is-builtin-module": "^3.1.0",
         "is-module": "^1.0.0",
         "resolve": "^1.19.0"
       }
@@ -9363,25 +8730,9 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
-    "assert": {
-      "version": "2.0.0",
-      "integrity": "sha1-lfwcYW1IcTUQaA8ury0Q3SLgLTI=",
-      "dev": true,
-      "requires": {
-        "es6-object-assign": "^1.1.0",
-        "is-nan": "^1.2.1",
-        "object-is": "^1.0.1",
-        "util": "^0.12.0"
-      }
-    },
     "astral-regex": {
       "version": "2.0.0",
       "integrity": "sha1-SDFDxWeu7UeFdZwIZXhtx319LjE=",
-      "dev": true
-    },
-    "available-typed-arrays": {
-      "version": "1.0.5",
-      "integrity": "sha1-kvlWFlAQadB9EO2y/DfT4cZRI7c=",
       "dev": true
     },
     "balanced-match": {
@@ -9428,17 +8779,8 @@
     },
     "builtin-modules": {
       "version": "3.3.0",
-      "integrity": "sha1-yuYoEriYAellYzbkYiPgMDhr57Y=",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
       "dev": true
-    },
-    "call-bind": {
-      "version": "1.0.2",
-      "integrity": "sha1-sdTonmiBGcPJqQOtMKuy9qkZvjw=",
-      "dev": true,
-      "requires": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
-      }
     },
     "caller-callsite": {
       "version": "2.0.0",
@@ -9574,7 +8916,7 @@
     },
     "commondir": {
       "version": "1.0.1",
-      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "dev": true
     },
     "compare-func": {
@@ -9769,15 +9111,6 @@
         "clone": "^1.0.2"
       }
     },
-    "define-properties": {
-      "version": "1.1.4",
-      "integrity": "sha1-CxTXvX++svNXLDp+2oDqXVf7BbE=",
-      "dev": true,
-      "requires": {
-        "has-property-descriptors": "^1.0.0",
-        "object-keys": "^1.1.1"
-      }
-    },
     "del": {
       "version": "6.1.1",
       "integrity": "sha1-O3AxTx7AqjJcaxTrNrlXhmce23o=",
@@ -9875,51 +9208,6 @@
       "requires": {
         "is-arrayish": "^0.2.1"
       }
-    },
-    "es-abstract": {
-      "version": "1.20.1",
-      "integrity": "sha1-AnKSzW70S9ErGRO4KBFvVHh9GBQ=",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "es-to-primitive": "^1.2.1",
-        "function-bind": "^1.1.1",
-        "function.prototype.name": "^1.1.5",
-        "get-intrinsic": "^1.1.1",
-        "get-symbol-description": "^1.0.0",
-        "has": "^1.0.3",
-        "has-property-descriptors": "^1.0.0",
-        "has-symbols": "^1.0.3",
-        "internal-slot": "^1.0.3",
-        "is-callable": "^1.2.4",
-        "is-negative-zero": "^2.0.2",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
-        "is-string": "^1.0.7",
-        "is-weakref": "^1.0.2",
-        "object-inspect": "^1.12.0",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.2",
-        "regexp.prototype.flags": "^1.4.3",
-        "string.prototype.trimend": "^1.0.5",
-        "string.prototype.trimstart": "^1.0.5",
-        "unbox-primitive": "^1.0.2"
-      }
-    },
-    "es-to-primitive": {
-      "version": "1.2.1",
-      "integrity": "sha1-5VzUyc3BiLzvsDs2bHNjI/xciYo=",
-      "dev": true,
-      "requires": {
-        "is-callable": "^1.1.4",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.2"
-      }
-    },
-    "es6-object-assign": {
-      "version": "1.1.0",
-      "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=",
-      "dev": true
     },
     "escalade": {
       "version": "3.1.1",
@@ -10107,7 +9395,7 @@
     },
     "estree-walker": {
       "version": "2.0.2",
-      "integrity": "sha1-UvAQF4wqTBF6d1fP6UKtt9LaTKw=",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true
     },
     "esutils": {
@@ -10238,14 +9526,6 @@
       "integrity": "sha1-dshYT0/IQ9tkcCpr0Eq3qL1mbaM=",
       "dev": true
     },
-    "for-each": {
-      "version": "0.3.3",
-      "integrity": "sha1-abRH6IoKXTLD5whPPxcQA0shN24=",
-      "dev": true,
-      "requires": {
-        "is-callable": "^1.1.3"
-      }
-    },
     "from2": {
       "version": "2.3.0",
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
@@ -10286,25 +9566,9 @@
       "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
       "dev": true
     },
-    "function.prototype.name": {
-      "version": "1.1.5",
-      "integrity": "sha1-zOBQX+H/uAUD5vnkbMZORqEqliE=",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.0",
-        "functions-have-names": "^1.2.2"
-      }
-    },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
-      "dev": true
-    },
-    "functions-have-names": {
-      "version": "1.2.3",
-      "integrity": "sha1-BAT+TuK6L2B/Dg7DyAuumUEzuDQ=",
       "dev": true
     },
     "get-caller-file": {
@@ -10312,29 +9576,10 @@
       "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
       "dev": true
     },
-    "get-intrinsic": {
-      "version": "1.1.1",
-      "integrity": "sha1-FfWfN2+FXERpY5SPDSTNNje0q8Y=",
-      "dev": true,
-      "requires": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
-      }
-    },
     "get-stream": {
       "version": "6.0.1",
       "integrity": "sha1-omLY7vZ6ztV8KFKtYWdSakPL97c=",
       "dev": true
-    },
-    "get-symbol-description": {
-      "version": "1.0.0",
-      "integrity": "sha1-f9uByQAQH71WTdXxowr1qtweWNY=",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.1"
-      }
     },
     "git-log-parser": {
       "version": "1.2.0",
@@ -10513,36 +9758,10 @@
         "function-bind": "^1.1.1"
       }
     },
-    "has-bigints": {
-      "version": "1.0.2",
-      "integrity": "sha1-CHG9Pj1RYm9soJZmaLo11WAtbqo=",
-      "dev": true
-    },
     "has-flag": {
       "version": "4.0.0",
       "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
       "dev": true
-    },
-    "has-property-descriptors": {
-      "version": "1.0.0",
-      "integrity": "sha1-YQcIYAYG02lh7QTBlhk7amB/qGE=",
-      "dev": true,
-      "requires": {
-        "get-intrinsic": "^1.1.1"
-      }
-    },
-    "has-symbols": {
-      "version": "1.0.3",
-      "integrity": "sha1-u3ssQ0klHc6HsSX3vfh0qnyLOfg=",
-      "dev": true
-    },
-    "has-tostringtag": {
-      "version": "1.0.0",
-      "integrity": "sha1-fhM4GKfTlHNPlB5zw9P5KR5liyU=",
-      "dev": true,
-      "requires": {
-        "has-symbols": "^1.0.2"
-      }
     },
     "he": {
       "version": "1.2.0",
@@ -10634,16 +9853,6 @@
       "integrity": "sha1-op2kJbSIBvNHZ6Tvzjlyaa8oQyw=",
       "dev": true
     },
-    "internal-slot": {
-      "version": "1.0.3",
-      "integrity": "sha1-c0fjB97uovqsKsYgXUvH00ln9Zw=",
-      "dev": true,
-      "requires": {
-        "get-intrinsic": "^1.1.0",
-        "has": "^1.0.3",
-        "side-channel": "^1.0.4"
-      }
-    },
     "into-stream": {
       "version": "6.0.0",
       "integrity": "sha1-S/wSRMASgiThi4hw6Fst6OZsZwI=",
@@ -10653,27 +9862,10 @@
         "p-is-promise": "^3.0.0"
       }
     },
-    "is-arguments": {
-      "version": "1.1.1",
-      "integrity": "sha1-FbP4j9oB8ql/7ITKdhpWDxI++ps=",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
-      }
-    },
     "is-arrayish": {
       "version": "0.2.1",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
-    },
-    "is-bigint": {
-      "version": "1.0.4",
-      "integrity": "sha1-CBR6GHW8KzIAXUHM2Ckd/8ZpHfM=",
-      "dev": true,
-      "requires": {
-        "has-bigints": "^1.0.1"
-      }
     },
     "is-binary-path": {
       "version": "2.1.0",
@@ -10683,19 +9875,13 @@
         "binary-extensions": "^2.0.0"
       }
     },
-    "is-boolean-object": {
-      "version": "1.1.2",
-      "integrity": "sha1-XG3CACRt2TIa5LiFoRS7H3X2Nxk=",
+    "is-builtin-module": {
+      "version": "3.1.0",
+      "integrity": "sha512-OV7JjAgOTfAFJmHZLvpSTb4qi0nIILDV1gWPYDnDJUTNFM5aGlRAhk4QcT8i7TuAleeEV5Fdkqn3t4mS+Q11fg==",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
+        "builtin-modules": "^3.0.0"
       }
-    },
-    "is-callable": {
-      "version": "1.2.4",
-      "integrity": "sha1-RzAdWN0CWUB4ZVR4U99tYf5HGUU=",
-      "dev": true
     },
     "is-core-module": {
       "version": "2.9.0",
@@ -10703,14 +9889,6 @@
       "dev": true,
       "requires": {
         "has": "^1.0.3"
-      }
-    },
-    "is-date-object": {
-      "version": "1.0.5",
-      "integrity": "sha1-CEHVU25yTCVZe/bqYuG9OCmN8x8=",
-      "dev": true,
-      "requires": {
-        "has-tostringtag": "^1.0.0"
       }
     },
     "is-directory": {
@@ -10728,14 +9906,6 @@
       "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
       "dev": true
     },
-    "is-generator-function": {
-      "version": "1.0.10",
-      "integrity": "sha1-8VWLrxrBfg3up8BBXEODUf8rPHI=",
-      "dev": true,
-      "requires": {
-        "has-tostringtag": "^1.0.0"
-      }
-    },
     "is-glob": {
       "version": "4.0.3",
       "integrity": "sha1-ZPYeQsu7LuwgcanawLKLoeZdUIQ=",
@@ -10749,32 +9919,10 @@
       "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
       "dev": true
     },
-    "is-nan": {
-      "version": "1.3.2",
-      "integrity": "sha1-BDpUreoxdItVts1OCara+mm9nh0=",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3"
-      }
-    },
-    "is-negative-zero": {
-      "version": "2.0.2",
-      "integrity": "sha1-e/bwOigAO4s5Zd46wm9mTXZfMVA=",
-      "dev": true
-    },
     "is-number": {
       "version": "7.0.0",
       "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=",
       "dev": true
-    },
-    "is-number-object": {
-      "version": "1.0.7",
-      "integrity": "sha1-WdUK2kxFJReE6ZBPUkbHQvB6Qvw=",
-      "dev": true,
-      "requires": {
-        "has-tostringtag": "^1.0.0"
-      }
     },
     "is-obj": {
       "version": "2.0.0",
@@ -10803,49 +9951,16 @@
     },
     "is-reference": {
       "version": "1.2.1",
-      "integrity": "sha1-iy2sCzcfS8mU/eq6nrVC0DAC0Lc=",
+      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
       "dev": true,
       "requires": {
         "@types/estree": "*"
-      }
-    },
-    "is-regex": {
-      "version": "1.1.4",
-      "integrity": "sha1-7vVmPNWfpMCuM5UFMj32hUuxWVg=",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
-      }
-    },
-    "is-shared-array-buffer": {
-      "version": "1.0.2",
-      "integrity": "sha1-jyWcVztgtqMtQFihoHQwwKc0THk=",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2"
       }
     },
     "is-stream": {
       "version": "2.0.1",
       "integrity": "sha1-+sHj1TuXrVqdCunO8jifWBClwHc=",
       "dev": true
-    },
-    "is-string": {
-      "version": "1.0.7",
-      "integrity": "sha1-DdEr8gBvJVu1j2lREO/3SR7rwP0=",
-      "dev": true,
-      "requires": {
-        "has-tostringtag": "^1.0.0"
-      }
-    },
-    "is-symbol": {
-      "version": "1.0.4",
-      "integrity": "sha1-ptrJO2NbBjymhyI23oiRClevE5w=",
-      "dev": true,
-      "requires": {
-        "has-symbols": "^1.0.2"
-      }
     },
     "is-text-path": {
       "version": "1.0.1",
@@ -10855,30 +9970,10 @@
         "text-extensions": "^1.0.0"
       }
     },
-    "is-typed-array": {
-      "version": "1.1.9",
-      "integrity": "sha1-JG130ocefZ9a6x1UufUscTKezmc=",
-      "dev": true,
-      "requires": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
-        "es-abstract": "^1.20.0",
-        "for-each": "^0.3.3",
-        "has-tostringtag": "^1.0.0"
-      }
-    },
     "is-unicode-supported": {
       "version": "0.1.0",
       "integrity": "sha1-PybHaoCVk7Ur+i7LVxDtJ3m1Iqc=",
       "dev": true
-    },
-    "is-weakref": {
-      "version": "1.0.2",
-      "integrity": "sha1-lSnzg6kzggXol2XgOS78LxAPBvI=",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2"
-      }
     },
     "isarray": {
       "version": "1.0.0",
@@ -11071,7 +10166,7 @@
     },
     "magic-string": {
       "version": "0.25.9",
-      "integrity": "sha1-3n+fr5HvihyR0CwuUxTIJ3283Rw=",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
       "dev": true,
       "requires": {
         "sourcemap-codec": "^1.4.8"
@@ -11345,7 +10440,6 @@
     },
     "npm": {
       "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-8.12.0.tgz",
       "integrity": "sha512-tueYJV0gAEv3unoGBrA0Qb/qZ8wdR4GF+aZYM5VO9pBNJhxW+JJje/xFm+ZFRvFfi7eWjba5KYlC2n2yvQSaIg==",
       "dev": true,
       "requires": {
@@ -13053,36 +12147,6 @@
         "path-key": "^3.0.0"
       }
     },
-    "object-inspect": {
-      "version": "1.12.0",
-      "integrity": "sha1-biwSDoaP0f0Yy08YwxdB0NbndvA=",
-      "dev": true
-    },
-    "object-is": {
-      "version": "1.1.5",
-      "integrity": "sha1-ud7qpfx/GEag+uzc7sE45XePU6w=",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
-      }
-    },
-    "object-keys": {
-      "version": "1.1.1",
-      "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4=",
-      "dev": true
-    },
-    "object.assign": {
-      "version": "4.1.2",
-      "integrity": "sha1-DtVKNC7Os3s4/3brgxoOeIy2OUA=",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3",
-        "has-symbols": "^1.0.1",
-        "object-keys": "^1.1.1"
-      }
-    },
     "once": {
       "version": "1.4.0",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
@@ -13489,16 +12553,6 @@
         "esprima": "~4.0.0"
       }
     },
-    "regexp.prototype.flags": {
-      "version": "1.4.3",
-      "integrity": "sha1-h8qzD4D2ZmAYGju3v1mBqHKzZ6w=",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "functions-have-names": "^1.2.2"
-      }
-    },
     "regexpp": {
       "version": "3.2.0",
       "integrity": "sha1-BCWido2PI7rXDKS5BGH6LxIT4bI=",
@@ -13700,16 +12754,6 @@
       "integrity": "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI=",
       "dev": true
     },
-    "side-channel": {
-      "version": "1.0.4",
-      "integrity": "sha1-785cj9wQTudRslxY1CkAEfpeos8=",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
-      }
-    },
     "signal-exit": {
       "version": "3.0.7",
       "integrity": "sha1-qaF2f4r4QVURTqq9c/mSc8j1mtk=",
@@ -13806,7 +12850,7 @@
     },
     "sourcemap-codec": {
       "version": "1.4.8",
-      "integrity": "sha1-6oBL2UhXQC5pktBaOO8a41qatMQ=",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "dev": true
     },
     "spawn-error-forwarder": {
@@ -13900,26 +12944,6 @@
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^6.0.1"
-      }
-    },
-    "string.prototype.trimend": {
-      "version": "1.0.5",
-      "integrity": "sha1-kUpluqqyX73U7ikcp93lfoacuNA=",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5"
-      }
-    },
-    "string.prototype.trimstart": {
-      "version": "1.0.5",
-      "integrity": "sha1-VGbZO6WM+iE0g5+B1/QkN+jAH+8=",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5"
       }
     },
     "strip-ansi": {
@@ -14163,17 +13187,6 @@
       "dev": true,
       "optional": true
     },
-    "unbox-primitive": {
-      "version": "1.0.2",
-      "integrity": "sha1-KQMgIQV9Xmzb0IxRKcIm3/jtb54=",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "has-bigints": "^1.0.2",
-        "has-symbols": "^1.0.3",
-        "which-boxed-primitive": "^1.0.2"
-      }
-    },
     "unique-string": {
       "version": "2.0.0",
       "integrity": "sha1-OcZFH4GvsnSd4rIz4/fF6IQ72J0=",
@@ -14204,19 +13217,6 @@
       "version": "4.0.1",
       "integrity": "sha1-tkLiGiZGgI/6F4xMX9o5hE4Szec=",
       "dev": true
-    },
-    "util": {
-      "version": "0.12.4",
-      "integrity": "sha1-ZhIaMUIN+PAcoMRkvhXfodGFAlM=",
-      "dev": true,
-      "requires": {
-        "inherits": "^2.0.3",
-        "is-arguments": "^1.0.4",
-        "is-generator-function": "^1.0.7",
-        "is-typed-array": "^1.1.3",
-        "safe-buffer": "^5.1.2",
-        "which-typed-array": "^1.1.2"
-      }
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -14270,31 +13270,6 @@
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"
-      }
-    },
-    "which-boxed-primitive": {
-      "version": "1.0.2",
-      "integrity": "sha1-E3V7yJsgmwSf5dhkMOIc9AqJqOY=",
-      "dev": true,
-      "requires": {
-        "is-bigint": "^1.0.1",
-        "is-boolean-object": "^1.1.0",
-        "is-number-object": "^1.0.4",
-        "is-string": "^1.0.5",
-        "is-symbol": "^1.0.3"
-      }
-    },
-    "which-typed-array": {
-      "version": "1.1.8",
-      "integrity": "sha1-DP1TQBpvM02Q7REldUpC7WY+sB8=",
-      "dev": true,
-      "requires": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
-        "es-abstract": "^1.20.0",
-        "for-each": "^0.3.3",
-        "has-tostringtag": "^1.0.0",
-        "is-typed-array": "^1.1.9"
       }
     },
     "word-wrap": {

--- a/package.json
+++ b/package.json
@@ -25,16 +25,15 @@
     "graphql-schema-linter": "^3.0.1"
   },
   "devDependencies": {
-    "@rollup/plugin-commonjs": "^17.0.0",
+    "@rollup/plugin-commonjs": "^22.0.0",
     "@rollup/plugin-json": "^4.1.0",
-    "@rollup/plugin-node-resolve": "^11.0.0",
+    "@rollup/plugin-node-resolve": "^13.3.0",
     "@rollup/plugin-typescript": "^8.3.2",
     "@tsconfig/node16-strictest-esm": "^1.0.1",
     "@types/mocha": "^9.1.1",
     "@types/node": "^16",
     "@typescript-eslint/eslint-plugin": "^5.26.0",
     "@typescript-eslint/parser": "^5.26.0",
-    "assert": "^2.0.0",
     "conventional-changelog-conventionalcommits": "^4.5.0",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^7.1.0",

--- a/test/assertions.ts
+++ b/test/assertions.ts
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import assert from 'node:assert';
 import type { ASTVisitor, ValidationContext } from 'graphql';
 import { validateSchemaDefinition } from 'graphql-schema-linter/lib/validator';
 import { Configuration } from 'graphql-schema-linter/lib/configuration';


### PR DESCRIPTION
The presence of this package appeared to be causing circular dependency issues with `util` and `inherits`, which led to improperly-generated rule code that could not run.
The built-in assertions provided by node are sufficient for what we need.

A couple of our rollup dependencies are also upgraded to avoid other issues.