### PR TITLE
feat(rule): Add rule to check that `id` is only used for Relay IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ Also, it adds some validation regarding Pinterest-specific rules:
 
 - Only edge type names may end in `Edge`. These object types are considered edge types.
 
+### `relay-id-field-type`
+
+This rule validates that when an `id` field is used, it is of an `ID` scalar type that is assumed to exist in the schema as a string scalar.
+
+Relay [imposes this requirement](https://github.com/facebook/relay/issues/1682#issuecomment-296393416) because it makes assumptions about any `id` field that it sees.
+
 ## Contributing
 
 See [`CONTRIBUTING.md`](CONTRIBUTING.md).

--- a/src/rules/relayIdFieldType.ts
+++ b/src/rules/relayIdFieldType.ts
@@ -1,0 +1,35 @@
+import type {
+  ASTVisitor,
+  FieldDefinitionNode,
+  ValidationContext,
+} from 'graphql';
+
+import { ValidationError } from 'graphql-schema-linter';
+import { isNamedTypeNode, isNonNullTypeNode } from '../utils';
+
+function isProperRelayIdField(field: FieldDefinitionNode): boolean {
+  return (
+    isNonNullTypeNode(field.type) &&
+    isNamedTypeNode(field.type.type) &&
+    field.type.type.name.value == 'ID'
+  );
+}
+
+export function RelayIdFieldType(context: ValidationContext): ASTVisitor {
+  return {
+    ObjectTypeDefinition(node) {
+      const idField = node.fields?.find(
+        (field: FieldDefinitionNode) => field.name.value === 'id',
+      );
+      if (idField && !isProperRelayIdField(idField)) {
+        context.reportError(
+          new ValidationError(
+            'relay-id-field-type',
+            `The "id" field on \`${node.name.value}\` must be a proper Relay ID field type, or renamed.`,
+            [node],
+          ),
+        );
+      }
+    },
+  };
+}

--- a/test/rules/testRelayIdFieldType.ts
+++ b/test/rules/testRelayIdFieldType.ts
@@ -1,0 +1,76 @@
+import { RelayIdFieldType } from '../../src/rules/relayIdFieldType';
+
+import { gql } from '../utils';
+
+import { expectPassesRule, expectFailsRule } from '../assertions';
+
+describe('RelayIdFieldType rule', () => {
+  it('allows types that have no id field', () => {
+    expectPassesRule(
+      RelayIdFieldType,
+      gql`
+        type Entity {
+          entityId: String!
+        }
+      `,
+    );
+  });
+
+  it('allows types with a correct id field', () => {
+    expectPassesRule(
+      RelayIdFieldType,
+      gql`
+        type Entity {
+          id: ID!
+        }
+      `,
+    );
+  });
+
+  it('allows types to use ID on other fields', () => {
+    expectPassesRule(
+      RelayIdFieldType,
+      gql`
+        type Entity {
+          myId: ID!
+        }
+      `,
+    );
+  });
+
+  it('disallows types with a wrong id field type', () => {
+    expectFailsRule(
+      RelayIdFieldType,
+      gql`
+        type Entity {
+          id: String!
+        }
+      `,
+      [
+        {
+          message:
+            'The "id" field on `Entity` must be a proper Relay ID field type, or renamed.',
+          locations: [{ line: 2, column: 9 }],
+        },
+      ],
+    );
+  });
+
+  it('disallows types with a non-nullable id field type', () => {
+    expectFailsRule(
+      RelayIdFieldType,
+      gql`
+        type Entity {
+          id: ID
+        }
+      `,
+      [
+        {
+          message:
+            'The "id" field on `Entity` must be a proper Relay ID field type, or renamed.',
+          locations: [{ line: 2, column: 9 }],
+        },
+      ],
+    );
+  });
+});


### PR DESCRIPTION
In Relay, `id` is [treated as a reserved word and must be a globally unique value](https://github.com/facebook/relay/issues/1682#issuecomment-296393416). That means when an `id` field is present on a type, it must be the type that Relay expects (a string type).

This linter assumes that an `ID` scalar is present in the schema, and checks that if an `id` field is present, it is using that type.